### PR TITLE
update pusher version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "pusher/pusher-php-server": "^3.4@dev"
+        "pusher/pusher-php-server": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I currently work with Laravel 7.30.4 and Pusher v4.1.5

I was modifying the package.json from the vendor but I had to add more steps in my deployment which update the Chatify package.json as shown in the PR

this little change lets me work with my current versions