### PR TITLE
dropping columns added to users table when reversing migrations

### DIFF
--- a/src/database/migrations/2019_10_18_223259_add_avatar_to_users.php
+++ b/src/database/migrations/2019_10_18_223259_add_avatar_to_users.php
@@ -29,7 +29,7 @@ class AddAvatarToUsers extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            $table->dropColumn('avatar');
         });
     }
 }

--- a/src/database/migrations/2019_10_20_211056_add_messenger_color_to_users.php
+++ b/src/database/migrations/2019_10_20_211056_add_messenger_color_to_users.php
@@ -29,7 +29,7 @@ class AddMessengerColorToUsers extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            $table->dropColumn('messenger_color');
         });
     }
 }

--- a/src/database/migrations/2019_10_22_000539_add_dark_mode_to_users.php
+++ b/src/database/migrations/2019_10_22_000539_add_dark_mode_to_users.php
@@ -29,7 +29,7 @@ class AddDarkModeToUsers extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            $table->dropColumn('dark_mode');
         });
     }
 }

--- a/src/database/migrations/2019_10_25_214038_add_active_status_to_users.php
+++ b/src/database/migrations/2019_10_25_214038_add_active_status_to_users.php
@@ -29,7 +29,7 @@ class AddActiveStatusToUsers extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            $table->dropColumn('active_status');
         });
     }
 }


### PR DESCRIPTION
### What was changed
I just made it so rolling back chatify migrations drops the columns included in users table: "avatar", "messenger_color", "dark_mode" and "active_status".

I think it's necessary, waiting for your opinion.

Thanks for the the package.