### PR TITLE
Hide Fields Feature, Bug Fix

### DIFF
--- a/src/ChatifyMessenger.php
+++ b/src/ChatifyMessenger.php
@@ -377,7 +377,7 @@ class ChatifyMessenger
     public function deleteMessage($id)
     {
         try {
-            $msg = Message::where('from_id', auth()->id())->fristOrFail($id);
+            $msg = Message::where('from_id', auth()->id())->where('id', $id)->fristOrFail();
                 if (isset($msg->attachment)) {
                     // delete file attached if exist
                     $path = config('chatify.attachments.folder') . '/' . json_decode($msg->attachment)->new_name;

--- a/src/Http/Controllers/Api/MessagesController.php
+++ b/src/Http/Controllers/Api/MessagesController.php
@@ -58,7 +58,7 @@ class MessagesController extends Controller
         // send the response
         return Response::json([
             'favorite' => $favorite,
-            'fetch' => $fetch ?? [],
+            'fetch' => $fetch->makeHidden(config('chatify.user_hidden_fields')) ?? [],
             'user_avatar' => $userAvatar ?? null,
         ]);
     }
@@ -257,7 +257,7 @@ class MessagesController extends Controller
     {
         $favorites = Favorite::where('user_id', Auth::user()->id)->get();
         foreach ($favorites as $favorite) {
-            $favorite->user = User::where('id', $favorite->favorite_id)->first();
+            $favorite->user = User::where('id', $favorite->favorite_id)->first()->makeHidden(config('chatify.user_hidden_fields'));
         }
         return Response::json([
             'total' => count($favorites),

--- a/src/Http/Controllers/MessagesController.php
+++ b/src/Http/Controllers/MessagesController.php
@@ -82,7 +82,7 @@ class MessagesController extends Controller
         // send the response
         return Response::json([
             'favorite' => $favorite,
-            'fetch' => $fetch ?? [],
+            'fetch' => $fetch->makeHidden(config('chatify.user_hidden_fields')) ?? [],
             'user_avatar' => $userAvatar ?? null,
         ]);
     }
@@ -287,7 +287,7 @@ class MessagesController extends Controller
                 'message' => 'User not found!',
             ], 401);
         }
-        $contactItem = Chatify::getContactItem($user);
+        $contactItem = Chatify::getContactItem($user->makeHidden(config('chatify.user_hidden_fields')));
 
         // send the response
         return Response::json([
@@ -327,7 +327,7 @@ class MessagesController extends Controller
             // get user data
             $user = User::where('id', $favorite->favorite_id)->first();
             $favoritesList .= view('Chatify::layouts.favorite', [
-                'user' => $user,
+                'user' => $user->makeHidden(config('chatify.user_hidden_fields')),
             ]);
         }
         // send the response

--- a/src/config/chatify.php
+++ b/src/config/chatify.php
@@ -101,4 +101,15 @@ return [
         '#ff2522',
         '#9C27B0',
     ],
+
+
+        /*
+    |-------------------------------------
+    | User Hidden Fields, in responses
+    |-------------------------------------
+    */
+    'user_hidden_fields' => (array) [
+        'email',
+        'password',
+    ],
 ];


### PR DESCRIPTION
Hala!

Changelog:
- $msg query, fristOrFail with id will not find the correct message. it needs a where before it
- Added small feature to hide sensitive columns from response if you want, such as email, api_key, whatever that you dont want to show in the responses. to avoid leaking some sensitive data.