### PR TITLE
Request Manipulation in Activity Status

### DIFF
--- a/src/Http/Controllers/Api/MessagesController.php
+++ b/src/Http/Controllers/Api/MessagesController.php
@@ -389,9 +389,8 @@ class MessagesController extends Controller
      */
     public function setActiveStatus(Request $request)
     {
-        $userId = $request['user_id'];
         $activeStatus = $request['status'] > 0 ? 1 : 0;
-        $status = User::where('id', $userId)->update(['active_status' => $activeStatus]);
+        $status = User::where('id', Auth::user()->id)->update(['active_status' => $activeStatus]);
         return Response::json([
             'status' => $status,
         ], 200);


### PR DESCRIPTION
The issue :
When changing the activity status it is making a request, and that request contains the user_id of the user. you can just basically edit the user_id to any other user_id and it'll update the status for any user without validation.

The Solution:
Just Changed the method from getting the user_id form the request into getting it from the current logged in user id.