### PR TITLE
fix: Prevent Users from updating each others statuses

### DIFF
--- a/src/Http/Controllers/Api/MessagesController.php
+++ b/src/Http/Controllers/Api/MessagesController.php
@@ -389,9 +389,8 @@ class MessagesController extends Controller
      */
     public function setActiveStatus(Request $request)
     {
-        $userId = $request['user_id'];
         $activeStatus = $request['status'] > 0 ? 1 : 0;
-        $status = User::where('id', $userId)->update(['active_status' => $activeStatus]);
+        $status = User::where('id', Auth::user()->id)->update(['active_status' => $activeStatus]);
         return Response::json([
             'status' => $status,
         ], 200);

--- a/src/Http/Controllers/MessagesController.php
+++ b/src/Http/Controllers/MessagesController.php
@@ -477,9 +477,8 @@ class MessagesController extends Controller
      */
     public function setActiveStatus(Request $request)
     {
-        $userId = $request['user_id'];
         $activeStatus = $request['status'] > 0 ? 1 : 0;
-        $status = User::where('id', $userId)->update(['active_status' => $activeStatus]);
+        $status = User::where('id', Auth::user()->id)->update(['active_status' => $activeStatus]);
         return Response::json([
             'status' => $status,
         ], 200);

--- a/src/assets/js/code.js
+++ b/src/assets/js/code.js
@@ -665,7 +665,7 @@ var activeStatusChannel = pusher.subscribe("presence-activeStatus");
 
 // Joined
 activeStatusChannel.bind("pusher:member_added", function (member) {
-  setActiveStatus(1, member.id);
+  setActiveStatus(1);
   $(".messenger-list-item[data-contact=" + member.id + "]")
     .find(".activeStatus")
     .remove();
@@ -676,7 +676,7 @@ activeStatusChannel.bind("pusher:member_added", function (member) {
 
 // Leaved
 activeStatusChannel.bind("pusher:member_removed", function (member) {
-  setActiveStatus(0, member.id);
+  setActiveStatus(0);
   $(".messenger-list-item[data-contact=" + member.id + "]")
     .find(".activeStatus")
     .remove();
@@ -1175,11 +1175,11 @@ function updateSettings() {
  * Set Active status
  *-------------------------------------------------------------
  */
-function setActiveStatus(status, user_id) {
+function setActiveStatus(status) {
   $.ajax({
     url: url + "/setActiveStatus",
     method: "POST",
-    data: { _token: access_token, user_id: user_id, status: status },
+    data: { _token: access_token, status: status },
     dataType: "JSON",
     success: (data) => {
       // Nothing to do


### PR DESCRIPTION
- Changed The setActiveStatus function in both controllers ( MessagesController & Api/MessagesController from getting the user id from the request to the current logged in user.
- Removed UserId from the function in the javascript "Code.js", updated the usage of the function.