### PR TITLE
api auth sanctum

### DIFF
--- a/src/Http/Controllers/Api/MessagesController.php
+++ b/src/Http/Controllers/Api/MessagesController.php
@@ -397,4 +397,17 @@ class MessagesController extends Controller
             'status' => $status,
         ], 200);
     }
+
+
+     // delete message
+
+     public function deleteMessage(Request $request)
+     {
+         // delete
+         $delete = Chatify::deleteMessage($request->id);
+         // send the response
+         return Response::json([
+             'deleted' => $delete ? 1 : 0,
+         ], 200);
+     }
 }

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -2,6 +2,13 @@
 
 use Illuminate\Support\Facades\Route;
 
+
+
+
+// for sanctum auth api it will help to get logged in user data 
+
+Route::middleware(['auth:sanctum'])->group(function(){
+
 /**
  * Authentication for pusher private channels
  */
@@ -73,3 +80,11 @@ Route::post('/updateSettings', 'MessagesController@updateSettings')->name('api.a
 Route::post('/setActiveStatus', 'MessagesController@setActiveStatus')->name('api.activeStatus.set');
 
 
+/**
+ * Delete Single Message 
+ */
+Route::post('/deleteMessage', 'MessagesController@deleteMessage')->name('api.message.delete');
+
+
+
+});


### PR DESCRIPTION
hi munafio I have added sanctum auth middleware in api  so that logged in user data will be fetched and also implemented single  message delete route and function.
Route::middleware(['auth:sanctum'])->group(function(){
Route::post('/deleteMessage', 'MessagesController@deleteMessage')->name('api.message.delete');

});

 // delete message

    public function deleteMessage(Request $request)
    {
        // delete
        $delete = Chatify::deleteMessage($request->id);

        // send the response
        return Response::json([
            'deleted' => $delete ? 1 : 0,
        ], 200);
    }