### PR TITLE
Fix pusher secret key being exposed to client.

### DIFF
--- a/src/config/chatify.php
+++ b/src/config/chatify.php
@@ -51,6 +51,16 @@ return [
             'useTLS' => env('PUSHER_SCHEME', 'https') === 'https',
         ],
     ],
+    'pusher-client' => [
+        'key' => env('PUSHER_APP_KEY'),
+        'options' => [
+            'cluster' => env('PUSHER_APP_CLUSTER', 'mt1'),
+            'host' => env('PUSHER_HOST') ?: 'ws-' . env('PUSHER_APP_CLUSTER', 'mt1') . '.pusher.com',
+            'port' => env('PUSHER_PORT', 443),
+            'encrypted' => true,
+            'useTLS' => env('PUSHER_SCHEME', 'https') === 'https',
+        ],
+    ],
 
     /*
     |-------------------------------------

--- a/src/config/chatify.php
+++ b/src/config/chatify.php
@@ -52,6 +52,7 @@ return [
         ],
     ],
     'pusher-client' => [
+        'debug' => env('APP_DEBUG', false),
         'key' => env('PUSHER_APP_KEY'),
         'options' => [
             'cluster' => env('PUSHER_APP_CLUSTER', 'mt1'),

--- a/src/views/layouts/footerLinks.blade.php
+++ b/src/views/layouts/footerLinks.blade.php
@@ -8,7 +8,7 @@
         allowedImages: {!! json_encode(config('chatify.attachments.allowed_images')) !!},
         allowedFiles: {!! json_encode(config('chatify.attachments.allowed_files')) !!},
         maxUploadSize: {{ Chatify::getMaxUploadSize() }},
-        pusher: {!! json_encode(config('chatify.pusher')) !!},
+        pusher: {!! json_encode(config('chatify.pusher-client')) !!},
         pusherAuthEndpoint: '{{route("pusher.auth")}}'
     };
     window.chatify.allAllowedExtensions = chatify.allowedImages.concat(chatify.allowedFiles);


### PR DESCRIPTION
Right now, whole pusher configuration including pusher client id and secret is exposed to the client which can be accessed using `window.chatify.pusher` in browser.

For this I created separate config for client and update the view to use that config.

Also according to pusher doc, host url for client should start with `ws`. Fixed that as well.