### PR TITLE
[fix bug] updateSelectedContact and IDinfo load if user_id != auth_id

### DIFF
--- a/src/MessageCollection.php
+++ b/src/MessageCollection.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Chatify;
+
+use Illuminate\Database\Eloquent\Collection;
+
+class MessageCollection extends Collection
+{
+    /**
+     * Mark all notifications as read.
+     *
+     * @return void
+     */
+    public function markAsRead()
+    {
+        $this->each->markAsRead();
+    }
+
+    /**
+     * Mark all notifications as unread.
+     *
+     * @return void
+     */
+    public function markAsUnread()
+    {
+        $this->each->markAsUnread();
+    }
+}

--- a/src/Models/ChMessage.php
+++ b/src/Models/ChMessage.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Chatify\Traits\UUID;
+use Chatify\MessageCollection;
+
 
 class ChMessage extends Model
 {
@@ -93,5 +95,17 @@ class ChMessage extends Model
     public function scopeUnread(Builder $query)
     {
         return $query->where('seen', 0);
+    }
+
+
+    /**
+     * Create a new database notification collection instance.
+     *
+     * @param  array  $models
+     * @return \Illuminate\Notifications\DatabaseNotificationCollection
+     */
+    public function newCollection(array $models = [])
+    {
+        return new MessageCollection($models);
     }
 }

--- a/src/Models/ChMessage.php
+++ b/src/Models/ChMessage.php
@@ -8,4 +8,90 @@ use Chatify\Traits\UUID;
 class ChMessage extends Model
 {
     use UUID;
+
+    /**
+     * Get the user who sent the message.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function from()
+    {
+        return $this->belongsTo(User::class, 'from_id');
+    }
+
+    /**
+     * Get the user who received the message.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function to()
+    {
+        return $this->belongsTo(User::class, 'to_id');
+    }
+
+    /**
+     * Mark the notification as read.
+     *
+     * @return void
+     */
+    public function markAsRead()
+    {
+        if ($this->seen !== 1) {
+            $this->forceFill(['seen' => 1])->save();
+        }
+    }
+
+    /**
+     * Mark the notification as unread.
+     *
+     * @return void
+     */
+    public function markAsUnread()
+    {
+        if ($this->seen !== 0) {
+            $this->forceFill(['seen' => 0])->save();
+        }
+    }
+
+    /**
+     * Determine if a notification has been read.
+     *
+     * @return bool
+     */
+    public function read()
+    {
+        return $this->seen !== 0;
+    }
+
+    /**
+     * Determine if a notification has not been read.
+     *
+     * @return bool
+     */
+    public function unread()
+    {
+        return $this->seen === 0;
+    }
+
+    /**
+     * Scope a query to only include read notifications.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeRead(Builder $query)
+    {
+        return $query->where('seen', 1);
+    }
+
+    /**
+     * Scope a query to only include unread notifications.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeUnread(Builder $query)
+    {
+        return $query->where('seen', 0);
+    }
 }

--- a/src/Traits/HasMessage.php
+++ b/src/Traits/HasMessage.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Chatify\Traits;
+
+use App\Models\ChMessage as Message;
+
+trait HasMessage
+{
+    /**
+     * Get the user who sent the message.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function messages()
+    {
+        return $this->hasMany(Message::class, 'to_id');
+    }
+
+    /**
+     * Get the entity's read message.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function readMessage()
+    {
+        return $this->messages()->read();
+    }
+
+    /**
+     * Get the entity's unread message.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function unreadMessage()
+    {
+        return $this->messages()->unread();
+    }
+}

--- a/src/assets/js/code.js
+++ b/src/assets/js/code.js
@@ -1324,7 +1324,7 @@ $(document).ready(function () {
     }
     const dataId = $(this).find("p[data-id]").attr("data-id");
     setMessengerId(dataId);
-    IDinfo(dataId);
+    // IDinfo(dataId);
   });
 
   // click action for favorite button

--- a/src/assets/js/code.js
+++ b/src/assets/js/code.js
@@ -72,12 +72,17 @@ function routerPush(title, url) {
   return window.history.pushState({}, title || document.title, url);
 }
 function updateSelectedContact(user_id) {
-  $(document).find(".messenger-list-item").removeClass("m-list-active");
-  $(document)
-    .find(
-      ".messenger-list-item[data-contact=" + (user_id || getMessengerId()) + "]"
-    )
-    .addClass("m-list-active");
+  user_id = user_id || getMessengerId();
+$(document).find(".messenger-list-item").removeClass("m-list-active");
+$(document)
+  .find(
+    ".messenger-list-item[data-contact=" + (user_id) + "]"
+  )
+  .addClass("m-list-active");
+
+  if (user_id != 0) {
+      IDinfo(user_id);
+  }
 }
 /**
  *-------------------------------------------------------------


### PR DESCRIPTION
I added a new feature when a user directly opens a URL like 
example.com/messages/101 then the 101 user is selected on the list and loads the user INFO with chats.

https://github.com/munafio/chatify/assets/17971022/7c64f609-dfad-4b5d-9a8a-88b709dedb9b

