### PR TITLE
Settings modal CSS fix

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -841,11 +841,13 @@ body {
   width: auto;
   max-width: 400px;
   margin: auto;
-  padding: 20px 40px;
   border-radius: 5px;
   text-align: center;
   box-shadow: 0px 3px 15px rgba(0, 0, 0, 0.27);
   transform: scale(0);
+}
+.app-modal-form {
+  padding: 20px 40px;
 }
 .app-modal-header {
   font-weight: 500;

--- a/src/views/layouts/modals.blade.php
+++ b/src/views/layouts/modals.blade.php
@@ -33,41 +33,43 @@
   <div class="app-modal" data-name="settings">
       <div class="app-modal-container">
           <div class="app-modal-card" data-name="settings" data-modal='0'>
-              <form id="update-settings" action="{{ route('avatar.update') }}" enctype="multipart/form-data" method="POST">
-                  @csrf
-                  {{-- <div class="app-modal-header">Update your profile settings</div> --}}
-                  <div class="app-modal-body">
-                      {{-- Udate profile avatar --}}
-                      <div class="avatar av-l upload-avatar-preview chatify-d-flex"
-                      style="background-image: url('{{ Chatify::getUserWithAvatar(Auth::user())->avatar }}');"
-                      ></div>
-                      <p class="upload-avatar-details"></p>
-                      <label class="app-btn a-btn-primary update" style="background-color:{{$messengerColor}}">
-                          Upload New
-                          <input class="upload-avatar chatify-d-none" accept="image/*" name="avatar" type="file" />
-                      </label>
-                      {{-- Dark/Light Mode  --}}
-                      <p class="divider"></p>
-                      <p class="app-modal-header">Dark Mode <span class="
-                        {{ Auth::user()->dark_mode > 0 ? 'fas' : 'far' }} fa-moon dark-mode-switch"
-                         data-mode="{{ Auth::user()->dark_mode > 0 ? 1 : 0 }}"></span></p>
-                      {{-- change messenger color  --}}
-                      <p class="divider"></p>
-                      {{-- <p class="app-modal-header">Change {{ config('chatify.name') }} Color</p> --}}
-                      <div class="update-messengerColor">
-                      @foreach (config('chatify.colors') as $color)
-                        <span style="background-color: {{ $color}}" data-color="{{$color}}" class="color-btn"></span>
-                        @if (($loop->index + 1) % 5 == 0)
-                            <br/>
-                        @endif
-                      @endforeach
-                      </div>
-                  </div>
-                  <div class="app-modal-footer">
-                      <a href="javascript:void(0)" class="app-btn cancel">Cancel</a>
-                      <input type="submit" class="app-btn a-btn-success update" value="Save Changes" />
-                  </div>
-              </form>
+                <div class="app-modal-form">
+                    <form id="update-settings" action="{{ route('avatar.update') }}" enctype="multipart/form-data" method="POST">
+                        @csrf
+                        {{-- <div class="app-modal-header">Update your profile settings</div> --}}
+                        <div class="app-modal-body">
+                            {{-- Udate profile avatar --}}
+                            <div class="avatar av-l upload-avatar-preview chatify-d-flex"
+                            style="background-image: url('{{ Chatify::getUserWithAvatar(Auth::user())->avatar }}');"
+                            ></div>
+                            <p class="upload-avatar-details"></p>
+                            <label class="app-btn a-btn-primary update" style="background-color:{{$messengerColor}}">
+                                Upload New
+                                <input class="upload-avatar chatify-d-none" accept="image/*" name="avatar" type="file" />
+                            </label>
+                            {{-- Dark/Light Mode  --}}
+                            <p class="divider"></p>
+                            <p class="app-modal-header">Dark Mode <span class="
+                                {{ Auth::user()->dark_mode > 0 ? 'fas' : 'far' }} fa-moon dark-mode-switch"
+                                data-mode="{{ Auth::user()->dark_mode > 0 ? 1 : 0 }}"></span></p>
+                            {{-- change messenger color  --}}
+                            <p class="divider"></p>
+                            {{-- <p class="app-modal-header">Change {{ config('chatify.name') }} Color</p> --}}
+                            <div class="update-messengerColor">
+                            @foreach (config('chatify.colors') as $color)
+                                <span style="background-color: {{ $color}}" data-color="{{$color}}" class="color-btn"></span>
+                                @if (($loop->index + 1) % 5 == 0)
+                                    <br/>
+                                @endif
+                            @endforeach
+                            </div>
+                        </div>
+                        <div class="app-modal-footer">
+                            <a href="javascript:void(0)" class="app-btn cancel">Cancel</a>
+                            <input type="submit" class="app-btn a-btn-success update" value="Save Changes" />
+                        </div>
+                    </form>
+                </div>
           </div>
       </div>
   </div>


### PR DESCRIPTION
In mobile view, the modal looks like this. This pull request attempts to fix the issue.

Before:
![chatify-mobile](https://github.com/munafio/chatify/assets/12048213/42a7702b-d7db-44a2-beb7-265562b37855)

After:
![Screenshot from 2024-06-15 22-25-20](https://github.com/munafio/chatify/assets/12048213/ab21ef17-4ed1-485f-b67f-0bf6532e91d9)

I've also seen pusher subscription issue when using Soketi websocket server. This can be easily solved by checking if the channel name contains `presence-` in it which seems to be the standard in pusher protocol. Also there is `href="#"` link for every anchor tag buttons that adds extra `#` in the url. We can get rid of them as well by adding `javascript:void(0)`. Let me know what do you think of it.

Waiting for your feedback.