### PR TITLE
Pusher subscription error for private and public channel fixed 🐛

### DIFF
--- a/src/ChatifyMessenger.php
+++ b/src/ChatifyMessenger.php
@@ -100,13 +100,19 @@ class ChatifyMessenger
      */
     public function pusherAuth($requestUser, $authUser, $channelName, $socket_id)
     {
-        // Auth data
-        $authData = json_encode([
-            'user_id' => $authUser->id,
-            'user_info' => [
-                'name' => $authUser->name
-            ]
-        ]);
+        $authData = null;
+
+        // Set auth data only if it is presence channel
+        if (strncmp($channelName, 'presence-', 9) == 0) {
+            // Auth data
+            $authData = json_encode([
+                'user_id' => $authUser->id,
+                'user_info' => [
+                    'name' => $authUser->name
+                ]
+            ]);
+        }
+
         // check if user authenticated
         if (Auth::check()) {
             if($requestUser->id == $authUser->id){


### PR DESCRIPTION
I have seen this PR #280 rejected before which hard coded the channel name. I have taken a different approach that adheres to the Pusher protocol standard. I have tested this solution in both Soketi and Pusher sandbox environments, and it works seamlessly in both cases. Please, see if you find any issue with this approach.