### PR TITLE
Limit the data retrieved for the user

### DIFF
--- a/src/Http/Controllers/MessagesController.php
+++ b/src/Http/Controllers/MessagesController.php
@@ -60,10 +60,11 @@ class MessagesController extends Controller
     public function idFetchData(Request $request)
     {
         $favorite = Chatify::inFavorite($request['id']);
-        $fetch = User::where('id', $request['id'])->first();
+        $fetch = User::where('id', $request['id'])->select('id', 'name', 'email')->first();
         if($fetch){
             $userAvatar = Chatify::getUserWithAvatar($fetch)->avatar;
         }
+        unset($fetch['email']);
         return Response::json([
             'favorite' => $favorite,
             'fetch' => $fetch ?? null,


### PR DESCRIPTION
We return the whole user's data in the request, this could potentially leak user's sensitive data.